### PR TITLE
Change default wss port from 8883 to 443

### DIFF
--- a/src/clients/BaseClient.js
+++ b/src/clients/BaseClient.js
@@ -86,7 +86,7 @@ export default class BaseClient extends events.EventEmitter {
       if(isNode() && !this.enforceWs) { 
         this.host = "ssl://" + config.org + ".messaging." + this.domainName + ":8883"; 
       } else {
-        this.host = "wss://" + config.org + ".messaging." + this.domainName + ":8883";
+        this.host = "wss://" + config.org + ".messaging." + this.domainName + ":443";
       }
 
       this.isQuickstart = false;


### PR DESCRIPTION
The documentation states port 443 for wss:
https://console.ng.bluemix.net/docs/services/IoT/iotplatform_task.html#iotplatform_subtask2

Both 8883 and 443 work but the inconsistency is confusing.